### PR TITLE
Configure Base API Routes for NFT Listings and Bids in nftopia-market…

### DIFF
--- a/nftopia-marketplace-service/app/Http/Controllers/Api/BidController.php
+++ b/nftopia-marketplace-service/app/Http/Controllers/Api/BidController.php
@@ -1,0 +1,62 @@
+<?php
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\PlaceBidRequest;
+use App\Models\Bid;
+use App\Models\Listing;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+class BidController extends Controller
+{
+    public function index(Listing $listing)
+    {
+        $bids = $listing->bids()->with('listing')->paginate(20);
+        return response()->json([
+            'success' => true,
+            'data' => $bids,
+        ]);
+    }
+
+    public function store(PlaceBidRequest $request, Listing $listing)
+    {
+        $bid = Bid::create([
+            'id' => (string) Str::uuid(),
+            'listing_id' => $listing->id,
+            'bidder_id' => $request->user()->id,
+            'amount' => $request->input('amount'),
+            'status' => 'pending',
+        ]);
+        // Trigger escrow hold (mocked)
+        Http::post(config('services.payment.url') . '/hold', [
+            'bid_id' => $bid->id,
+            'amount' => $bid->amount,
+            'user_id' => $bid->bidder_id,
+        ]);
+        return response()->json([
+            'success' => true,
+            'data' => $bid,
+        ], 201);
+    }
+
+    public function show(Listing $listing, Bid $bid)
+    {
+        return response()->json([
+            'success' => true,
+            'data' => $bid->load('listing'),
+        ]);
+    }
+
+    public function destroy(Listing $listing, Bid $bid)
+    {
+        if ($bid->listing->highestBid()?->id !== $bid->id) {
+            $bid->update(['status' => 'canceled']);
+            return response()->json(null, 204);
+        }
+        return response()->json([
+            'success' => false,
+            'message' => 'Cannot retract highest bid.'
+        ], 400);
+    }
+}

--- a/nftopia-marketplace-service/app/Http/Controllers/Api/ListingController.php
+++ b/nftopia-marketplace-service/app/Http/Controllers/Api/ListingController.php
@@ -1,0 +1,73 @@
+<?php
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\CreateListingRequest;
+use App\Http\Requests\UpdateListingRequest;
+use App\Models\Listing;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+class ListingController extends Controller
+{
+    public function index(Request $request)
+    {
+        $perPage = $request->input('per_page', 20);
+        $cacheKey = "active_listings_page_{$request->get('page', 1)}_{$perPage}";
+        $listings = Cache::remember($cacheKey, now()->addMinutes(5), function () use ($perPage) {
+            return Listing::where('status', 'active')
+                ->when(request('listing_type'), fn($q) => $q->where('listing_type', request('listing_type')))
+                ->with('bids')
+                ->paginate($perPage);
+        });
+        return response()->json([
+            'success' => true,
+            'data' => $listings,
+        ]);
+    }
+
+    public function store(CreateListingRequest $request)
+    {
+        $data = $request->validated();
+        $data['id'] = (string) Str::uuid();
+        $listing = Listing::create($data);
+        return response()->json([
+            'success' => true,
+            'data' => $listing,
+        ], 201);
+    }
+
+    public function show(Listing $listing)
+    {
+        $data = Cache::remember("listing_{$listing->id}", 300, function () use ($listing) {
+            return $listing->load('bids');
+        });
+        return response()->json([
+            'success' => true,
+            'data' => $data,
+        ]);
+    }
+
+    public function update(UpdateListingRequest $request, Listing $listing)
+    {
+        $listing->update($request->validated());
+        return response()->json([
+            'success' => true,
+            'data' => $listing,
+        ]);
+    }
+
+    public function destroy(Request $request, Listing $listing)
+    {
+        // Add policy/authorization as needed
+        if ($request->user()->id !== $listing->seller_id || $listing->status !== 'active') {
+            return response()->json([
+                'success' => false,
+                'message' => 'Unauthorized or listing not active.'
+            ], 403);
+        }
+        $listing->update(['status' => 'canceled']);
+        return response()->json(null, 204);
+    }
+}

--- a/nftopia-marketplace-service/app/Http/Requests/CreateListingRequest.php
+++ b/nftopia-marketplace-service/app/Http/Requests/CreateListingRequest.php
@@ -1,0 +1,33 @@
+<?php
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateListingRequest extends FormRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        $minPrice = config('marketplace.min_listing_price', 0.01);
+        return [
+            'nft_contract_address' => 'required|string|size:42',
+            'token_id' => 'required|string',
+            'seller_id' => 'required|uuid|exists:users,id',
+            'listing_type' => 'required|in:fixed_price,auction',
+            'price' => "required|numeric|min:{$minPrice}",
+            'auction_end' => 'nullable|date|after:now',
+            'metadata' => 'nullable|array',
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'seller_id' => auth()->id() ?? $this->input('seller_id'),
+        ]);
+    }
+}

--- a/nftopia-marketplace-service/app/Http/Requests/PlaceBidRequest.php
+++ b/nftopia-marketplace-service/app/Http/Requests/PlaceBidRequest.php
@@ -1,0 +1,49 @@
+<?php
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Http;
+
+class PlaceBidRequest extends FormRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'amount' => 'required|numeric',
+        ];
+    }
+
+    public function withValidator($validator)
+    {
+        $validator->after(function ($validator) {
+            $listing = $this->route('listing');
+            if ($listing->listing_type !== 'auction') {
+                $validator->errors()->add('listing_type', 'Only auction listings accept bids.');
+                return;
+            }
+            if ($listing->auction_end && now()->greaterThan($listing->auction_end)) {
+                $validator->errors()->add('auction_end', 'Auction has ended.');
+                return;
+            }
+            $highestBid = $listing->bids()->orderByDesc('amount')->first();
+            $minBid = $highestBid ? $highestBid->amount + 0.01 : $listing->price;
+            if ($this->input('amount') <= $minBid) {
+                $validator->errors()->add('amount', "Bid must be greater than current highest bid ({$minBid}).");
+            }
+            // Ownership verification (mocked, adjust as needed)
+            $response = Http::post(config('services.nftopia_onchain.url') . '/verify-ownership', [
+                'nft_contract_address' => $listing->nft_contract_address,
+                'token_id' => $listing->token_id,
+                'owner_id' => $this->input('bidder_id', auth()->id()),
+            ]);
+            if (!$response->json('owned')) {
+                $validator->errors()->add('ownership', 'You do not own this NFT or are not authorized.');
+            }
+        });
+    }
+}

--- a/nftopia-marketplace-service/app/Http/Requests/UpdateListingRequest.php
+++ b/nftopia-marketplace-service/app/Http/Requests/UpdateListingRequest.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateListingRequest extends FormRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'price' => 'sometimes|numeric|min:' . config('marketplace.min_listing_price', 0.01),
+            'auction_end' => 'sometimes|nullable|date|after:now',
+            'status' => 'sometimes|in:cancelled',
+        ];
+    }
+}

--- a/nftopia-marketplace-service/routes/api.php
+++ b/nftopia-marketplace-service/routes/api.php
@@ -1,0 +1,22 @@
+<?php
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\ListingController;
+use App\Http\Controllers\Api\BidController;
+
+Route::middleware(['auth:sanctum', 'throttle:100,1'])->prefix('listings')->group(function () {
+    Route::get('/', [ListingController::class, 'index']);
+    Route::post('/', [ListingController::class, 'store']);
+    Route::prefix('{listing}')->group(function () {
+        Route::get('/', [ListingController::class, 'show']);
+        Route::put('/', [ListingController::class, 'update']);
+        Route::delete('/', [ListingController::class, 'destroy']);
+        Route::prefix('bids')->group(function () {
+            Route::get('/', [BidController::class, 'index']);
+            Route::post('/', [BidController::class, 'store']);
+            Route::prefix('{bid}')->group(function () {
+                Route::get('/', [BidController::class, 'show']);
+                Route::delete('/', [BidController::class, 'destroy']);
+            });
+        });
+    });
+});


### PR DESCRIPTION
This PR introduces foundational API endpoints for managing NFT listings and bidding operations in the marketplace service. These routes form the core interaction layer between the frontend client and the trading engine, enabling users to list NFTs for sale (fixed price or auction) and place, view, or retract bids.

The implementation follows RESTful conventions and includes robust validation, security, caching, and integration with external services for ownership verification and payment escrow.

✅ Key Features Implemented
Listings Endpoints
GET /api/listings – Retrieve paginated active listings (cached)
POST /api/listings – Create a new listing with validation
GET /api/listings/{id} – Fetch detailed listing info
PUT /api/listings/{id} – Update listing (e.g., price, auction end)
DELETE /api/listings/{id} – Cancel an active listing
Bids Endpoints
GET /api/listings/{id}/bids – List all bids on a listing
POST /api/listings/{id}/bids – Place a new bid (with price validation)
GET /api/listings/{id}/bids/{bidId} – View specific bid details
DELETE /api/listings/{id}/bids/{bidId} – Retract a bid (if allowed)
